### PR TITLE
Update compile script to support new headless chromium config

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -38,6 +38,9 @@ echo "-----> Installation done"
 
 cat <<EOF > $BUILD_DIR/.profile.d/heroku-playwright-python-browsers-defaults.sh
 CHROMIUM_EXECUTABLE_PATH=\$(find ~+ -type f -name "chrome")
+if [ "\$CHROMIUM_EXECUTABLE_PATH" = "" ]; then
+  CHROMIUM_EXECUTABLE_PATH=\$(find ~+ -type f -name "headless_shell")
+fi
 echo "----> CHROMIUM_EXECUTABLE_PATH is \$CHROMIUM_EXECUTABLE_PATH"
 if [ "\$CHROMIUM_EXECUTABLE_PATH" != "" ]; then
   export CHROMIUM_EXECUTABLE_PATH=\$CHROMIUM_EXECUTABLE_PATH


### PR DESCRIPTION
Playwright 1.49.0+ has rolled in Chrome 112's changes to their headless browser.

Chrome blog: https://developer.chrome.com/blog/chrome-headless-shell

Related playwright issue/explainer: https://github.com/microsoft/playwright/issues/33566

What this actually means is that `playwright install chromium` installs both full Chromium, as well as Chromium Headless Shell.

At the time of writing, that comes out to ~199mb. I only first noticed this after upgrading playwright because Heroku was rejecting the build for exceeding the 500mb slug limit.

After digging around, instead of `playwright install chromium`, we should now be using `playwright install chromium-headless-shell` (or `playwright install chromium --only-shell`, appears to be the same thing) if we don't want full Chromium. This'll install only the headless version, ~77mb at the time of writing.

Unfortunately it's not as simple as just doing that though. The executable for the headless Chromium isn't called just `chrome`, it's called `headless_shell` - which means that `CHROMIUM_EXECUTABLE_PATH` isn't automatically set by this buildpack anymore if you only need the headless version installed.

All this PR does is update the compile script; if `chrome` isn't found, then it looks for `headless_shell` - and if that's found, then it sets `CHROMIUM_EXECUTABLE_PATH` to that.